### PR TITLE
Fix compilation errors on OS X 10.9 Mavericks.

### DIFF
--- a/src/include/gng/counter.h
+++ b/src/include/gng/counter.h
@@ -1,14 +1,14 @@
 #ifndef COUNTER_H__
 #define COUNTER_H__
 
-#include <tr1/unordered_map>
+#include "port/port.h"
 #include <stdexcept>
 #include <string>
 
 namespace gng {
 
 template <class Key,class T>
-class Counter : public std::tr1::unordered_map<Key,T> {
+class Counter : public std::unordered_map<Key,T> {
 
 
 public:

--- a/src/include/gng/symbol-map.h
+++ b/src/include/gng/symbol-map.h
@@ -2,22 +2,21 @@
 #define GNG_SYMBOL_MAP_H__
 
 #include "string.h"
-#include <tr1/unordered_map>
-#include <tr1/unordered_set>
+#include "port/port.h"
 #include <vector>
 #include <iostream>
 
 namespace gng {
 
-template < class Key, class T, class Hash = std::tr1::hash<Key> >
-class SymbolMap : public std::tr1::unordered_map< Key, T, Hash > {
+template < class Key, class T, class Hash = std::hash<Key> >
+class SymbolMap : public std::unordered_map< Key, T, Hash > {
 
 protected:
 
     std::vector<T> nextKeys_;
 
 public:
-    SymbolMap() : std::tr1::unordered_map<Key,T,Hash>() { }
+    SymbolMap() : std::unordered_map<Key,T,Hash>() { }
 
     unsigned numElements() { return this->size() - nextKeys_.size(); }
 
@@ -38,9 +37,9 @@ public:
         }
         return -1;
     }
-    
+
     void removeElements(const std::vector<T> & vec) {
-        std::tr1::unordered_set<T> mySet;
+        std::unordered_set<T> mySet;
         for(typename std::vector<T>::const_iterator it = vec.begin(); it != vec.end(); it++)
             mySet.insert(*it);
         std::vector<Key> removeKeys; removeKeys.reserve(vec.size());

--- a/src/include/gng/symbol-set.h
+++ b/src/include/gng/symbol-set.h
@@ -2,23 +2,23 @@
 #define GNG_SYMBOL_SET_H__
 
 #include "string.h"
-#include <tr1/unordered_map>
+#include "port/port.h"
 #include <vector>
 
 namespace gng {
 
-template < class Key, class T, class Hash = std::tr1::hash<Key> >
+template < class Key, class T, class Hash = std::hash<Key> >
 class SymbolSet {
 
 public:
 
-    typedef std::tr1::unordered_map< Key, T, Hash > Map;
+    typedef std::unordered_map< Key, T, Hash > Map;
     typedef std::vector< Key > Vocab;
     typedef typename Map::iterator iterator;
     typedef typename Map::const_iterator const_iterator;
 
 protected:
-    
+
     Map map_;
     Vocab vocab_;
     std::vector<T> nextIds_;

--- a/src/include/pialign/definitions.h
+++ b/src/include/pialign/definitions.h
@@ -12,8 +12,7 @@
 // enables compression
 // #define COMPRESS_ON
 
-#include <tr1/unordered_set>
-#include <tr1/unordered_map>
+#include "port/port.h"
 #include "gng/string.h"
 #include "gng/symbol-set.h"
 #include "gng/symbol-map.h"
@@ -196,11 +195,11 @@ public:
 
 typedef gng::SymbolSet< std::string, WordId > WordSymbolSet;
 typedef gng::SymbolSet< WordPairId, WordId > PairWordSet;
-typedef std::tr1::unordered_map< WordPairId, Prob > PairProbMap;
+typedef std::unordered_map< WordPairId, Prob > PairProbMap;
 typedef gng::SymbolMap< Span, int, SpanHash > SpanSymbolMap;
 typedef std::vector< Span > SpanVec;
-typedef std::tr1::unordered_set< Span, SpanHash > SpanSet;
-typedef std::vector< SpanVec > Agendas; 
+typedef std::unordered_set< Span, SpanHash > SpanSet;
+typedef std::vector< SpanVec > Agendas;
 typedef std::pair<Prob, Span> ProbSpan;
 typedef std::vector< ProbSpan > ProbSpanVec;
 
@@ -305,10 +304,10 @@ public:
 
 };
 
-class SpanProbMap : public std::tr1::unordered_map< Span, Prob, SpanHash > {
+class SpanProbMap : public std::unordered_map< Span, Prob, SpanHash > {
 public:
 
-    SpanProbMap() : std::tr1::unordered_map< Span, Prob, SpanHash >() { }
+    SpanProbMap() : std::unordered_map< Span, Prob, SpanHash >() { }
     virtual ~SpanProbMap() { }
 
     Prob getProb(const Span & mySpan) const {

--- a/src/include/pialign/dirichletdist.h
+++ b/src/include/pialign/dirichletdist.h
@@ -39,7 +39,7 @@ public:
     }
 
     std::vector<Prob> getAllProbs() const {
-        std::vector<Prob> ret();
+        std::vector<Prob> ret;
         for(T i = 0; i < ret.size(); i++)
             ret[i] = getProb(i);
         return ret;

--- a/src/include/pialign/pialign.h
+++ b/src/include/pialign/pialign.h
@@ -9,7 +9,6 @@
 #include "pialign/look-base.h"
 #include "gng/string.h"
 #include "gng/symbol-set.h"
-#include <tr1/unordered_map>
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/src/include/pialign/pydist.h
+++ b/src/include/pialign/pydist.h
@@ -61,10 +61,10 @@ template < class T >
 class PySparseIndex {
 protected:
     typedef PyTableSet<T> TSet;
-    std::tr1::unordered_map< int, TSet > idx_;
+    std::unordered_map< int, TSet > idx_;
 public:
-    typedef typename std::tr1::unordered_map< int, TSet >::const_iterator const_iterator;
-    typedef typename std::tr1::unordered_map< int, TSet >::iterator iterator;
+    typedef typename std::unordered_map< int, TSet >::const_iterator const_iterator;
+    typedef typename std::unordered_map< int, TSet >::iterator iterator;
     iterator begin() { return idx_.begin(); }
     iterator end() { return idx_.end(); }
     TSet & iterTableSet(iterator it) { return it->second; }

--- a/src/include/port/port.h
+++ b/src/include/port/port.h
@@ -1,0 +1,22 @@
+#ifndef PIALIGN_PORT_PORT_H_
+#define PIALIGN_PORT_PORT_H_
+
+// As of OS X 10.9, it looks like C++ TR1 headers are removed from the
+// search paths. Instead, we can include C++11 headers.
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+#else // Assuming older OS X, Linux or similar platforms
+#include <tr1/functional>
+#include <tr1/unordered_map>
+#include <tr1/unordered_set>
+
+namespace std {
+using tr1::hash;
+using tr1::unordered_map;
+using tr1::unordered_set;
+} // namespace std
+#endif
+
+#endif // PIALIGN_PORT_PORT_H_

--- a/src/lib/model-length.cc
+++ b/src/lib/model-length.cc
@@ -2,7 +2,6 @@
 #include "pialign/model-length.h"
 
 using namespace std;
-using namespace std::tr1;
 using namespace pialign;
 using namespace gng;
 

--- a/src/lib/pialign.cc
+++ b/src/lib/pialign.cc
@@ -23,12 +23,11 @@
 #include "pialign/compress_stream.hpp"
 #endif
 
-#ifdef HAVE_CONFIG_H 
+#ifdef HAVE_CONFIG_H
 #include "pialign/config.h"
 #endif
 
 using namespace std;
-using namespace std::tr1;
 using namespace pialign;
 using namespace gng;
 


### PR DESCRIPTION
On OS X 10.9, it looks like Clang is used by default, it does not look for
g++ 4.2 TR1 headers.
