### PR TITLE
Include the OS X specific header to use the OS specific macros.

### DIFF
--- a/src/include/port/port.h
+++ b/src/include/port/port.h
@@ -3,7 +3,12 @@
 
 // As of OS X 10.9, it looks like C++ TR1 headers are removed from the
 // search paths. Instead, we can include C++11 headers.
-#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#endif
+
+#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_9) && \
+  MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
Hi,
The pull request I sent on Oct 29 in which I was supposed to fix compilation errors on OS X 10.9 (Mavericks) was not correct. This pull request fixes this issue.

The commit 2baa370 assumed that the macros for checking whether the user
compiles on OS X 10.9 are defined, but it was wrong because the header
which defines the macros was not included. This commit fixes this issue.
