### PR TITLE
Fix comparison of integers with the bool type in test cases for the Trie class

### DIFF
--- a/src/test/maintest-trie.cc
+++ b/src/test/maintest-trie.cc
@@ -49,14 +49,14 @@ int testFind() {
     if(!trie.insert("babino",6,5)) { return er("testFind", "insert babino"); }
     if(!trie.insert("babel",5,6)) { return er("testFind", "insert babel"); }
 
-    if(!trie.findValue("abracadabra",11) == 1) { return er("testFind", "find abracadabra"); }
-    if(!trie.findValue("abs",3) == 2) { return er("testFind", "find abs"); }
-    if(!trie.findValue("babies",6) == 3) { return er("testFind", "find babies"); }
-    if(!trie.findValue("baby",4) == 4) { return er("testFind", "find baby"); }
-    if(!trie.findValue("babino",6) == 5) { return er("testFind", "find babino"); }
-    if(!trie.findValue("babel",5) == 6) { return er("testFind", "find babel"); }
-    if(!trie.findValue("bab",3) == -1) { return er("testFind", "find bab"); }
-    if(!trie.findValue("babys",5) == -1) { return er("testFind", "find babys"); }
+    if(trie.findValue("abracadabra",11) != 1) { return er("testFind", "find abracadabra"); }
+    if(trie.findValue("abs",3) != 2) { return er("testFind", "find abs"); }
+    if(trie.findValue("babies",6) != 3) { return er("testFind", "find babies"); }
+    if(trie.findValue("baby",4) != 4) { return er("testFind", "find baby"); }
+    if(trie.findValue("babino",6) != 5) { return er("testFind", "find babino"); }
+    if(trie.findValue("babel",5) != 6) { return er("testFind", "find babel"); }
+    if(trie.findValue("bab",3) != -1) { return er("testFind", "find bab"); }
+    if(trie.findValue("babys",5) != -1) { return er("testFind", "find babys"); }
 
     return er("testFind", 0);
 


### PR DESCRIPTION
This commit fixes comparisons of different types when checking the
return values of `trie.findValue()` in the test cases in testFind().
In test cases in testErase(), the return values of that function are
correctly checked with the binary operation "!=".
