### PR TITLE
Fixes automake error caused by the commit 9635494bf.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS = src
+AUTOMAKE_OPTIONS = foreign
 
 dist_pkglibexec_SCRIPTS = \
 script/aer.pl \


### PR DESCRIPTION
Hi Graham,

There was a side effect on the commit 9635494bf when running automake. Apologize for inconvenience.

The commit 9635494bf renamed README with README.md, leading to
the situation automake is complaining that there is no `README`
in this project unless we specify the option `foreign` into Makefile.am.
