### PR TITLE
Change Makefile.am so that we can run unit tests with `make check`.

### DIFF
--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -1,7 +1,8 @@
 
 AM_CPPFLAGS = -I$(srcdir)/../include
 
-bin_PROGRAMS = test-pialign test-trie
+check_PROGRAMS = test-pialign test-trie
+TESTS = test-pialign test-trie
 
 test_pialign_SOURCES = maintest-pialign.cc
 test_pialign_LDADD = ../lib/libpialign.la


### PR DESCRIPTION
Test programs should be listed in `check_PROGRAMS` instead of `bin_PROGRAMS`. Users might not want to install the test programs.
