### PR TITLE
Asymmetric priors for the two language sides

### DIFF
--- a/src/include/pialign/base-compound.h
+++ b/src/include/pialign/base-compound.h
@@ -69,9 +69,9 @@ public:
         dist_ = DirichletDist<int>(1.0,measures_.size());
     }
 
-    void trainPoisson(Prob avgLen, Prob nullProb) {
+    void trainPoisson(Prob avgLenE, Prob nullProbE, Prob avgLenF, Prob nullProbF) {
         for(unsigned i = 0; i < measures_.size(); i++)
-            measures_[i]->trainPoisson(avgLen,nullProb);
+            measures_[i]->trainPoisson(avgLenE,nullProbE,avgLenF,nullProbF);
     }
 
     void trainUnigrams(const Corpus & es, int eSize, const Corpus & fs, int fSize) {
@@ -84,12 +84,14 @@ public:
         for(unsigned i = 0; i < measures_.size(); i++)
             measures_[i]->setDebug(debug);
     }
-    void setMaxLen(int maxLen) { 
-        maxLen_ = maxLen;
+    void setMaxLen(int maxLenE, int maxLenF) { 
+        maxLen_e_ = maxLenE;
+        maxLen_f_ = maxLenF;
         for(unsigned i = 0; i < measures_.size(); i++)
-            measures_[i]->setMaxLen(maxLen);
+            measures_[i]->setMaxLen(maxLenE, maxLenF);
     }
-    int getMaxLen() const { return maxLen_; }
+    int getMaxLenE() const { return maxLen_e_; }
+    int getMaxLenF() const { return maxLen_f_; }
 
     virtual SpanProbMap * getBaseChart(const WordString & e, const WordString & f) const;
 

--- a/src/include/pialign/base-measure.h
+++ b/src/include/pialign/base-measure.h
@@ -11,10 +11,13 @@ class BaseMeasure {
 
 protected:
 
-    Prob avgLen_;
-    int maxLen_;
+    Prob avgLen_e_;
+    Prob avgLen_f_;
+    int maxLen_e_;
+    int maxLen_f_;
 
-    std::vector<Prob> poisProbs_;
+    std::vector<Prob> poisProbs_e_;
+    std::vector<Prob> poisProbs_f_;
     std::vector<Prob> unigrams_;
     std::vector<Prob> baseProbs_;
     std::vector< std::vector<Prob> > baseElems_;
@@ -46,20 +49,31 @@ public:
     //  by fallbacks, etc in the model, chart is the overall chart
     virtual SpanProbMap * getBaseChart(const WordString & e, const WordString & f) const = 0;
 
-    virtual void trainPoisson(Prob avgLen, Prob nullProb) {
+    virtual void trainPoisson(Prob avgLenE, Prob nullProbE, Prob avgLenF, Prob nullProbF) {
 
-        // initialize poisson probabilities
+        // initialize poisson probabilities (E side)
         Prob poisSum = 0.0;
-        poisProbs_.resize(maxLen_+1,0);
-        poisProbs_[0] = exp(-1*avgLen);
-        for(int i = 1; i <= maxLen_; i++) 
-            poisProbs_[i] = poisProbs_[i-1] * avgLen / i;
-        for(int i = 1; i <= maxLen_; i++)
-            poisSum += poisProbs_[i];
-        for(int i = 1; i <= maxLen_; i++)
-            poisProbs_[i] = log(poisProbs_[i]/poisSum*(1-nullProb));
-        poisProbs_[0] = log(nullProb); 
+        poisProbs_e_.resize(maxLen_e_+1,0);
+        poisProbs_e_[0] = exp(-1*avgLenE);
+        for(int i = 1; i <= maxLen_e_; i++) 
+            poisProbs_e_[i] = poisProbs_e_[i-1] * avgLenE / i;
+        for(int i = 1; i <= maxLen_e_; i++)
+            poisSum += poisProbs_e_[i];
+        for(int i = 1; i <= maxLen_e_; i++)
+            poisProbs_e_[i] = log(poisProbs_e_[i]/poisSum*(1-nullProbE));
+        poisProbs_e_[0] = log(nullProbE); 
 
+        // initialize poisson probabilities (F side)
+        poisSum = 0.0;
+        poisProbs_f_.resize(maxLen_f_+1,0);
+        poisProbs_f_[0] = exp(-1*avgLenF);
+        for(int i = 1; i <= maxLen_f_; i++) 
+            poisProbs_f_[i] = poisProbs_f_[i-1] * avgLenF / i;
+        for(int i = 1; i <= maxLen_f_; i++)
+            poisSum += poisProbs_f_[i];
+        for(int i = 1; i <= maxLen_f_; i++)
+            poisProbs_f_[i] = log(poisProbs_f_[i]/poisSum*(1-nullProbF));
+        poisProbs_f_[0] = log(nullProbF); 
     }
 
     virtual void trainUnigrams(const Corpus & es, int eSize, const Corpus & fs, int fSize) {
@@ -82,8 +96,9 @@ public:
 //
 //    }
     virtual void setDebug(int debug) { debug_ = debug; }
-    virtual void setMaxLen(int maxLen) { maxLen_ = maxLen; }
-    virtual int getMaxLen() const { return maxLen_; }
+    virtual void setMaxLen(int maxLenE, int maxLenF) { maxLen_e_ = maxLenE; maxLen_f_ = maxLenF; }
+    virtual int getMaxLenE() const { return maxLen_e_; }
+    virtual int getMaxLenF() const { return maxLen_f_; }
 
     virtual void add(Span & span, WordId pid, Prob baseProb, const std::vector<Prob> & baseElems) {
         if((int)baseProbs_.size() <= pid) {

--- a/src/include/pialign/model-base.h
+++ b/src/include/pialign/model-base.h
@@ -16,7 +16,8 @@ class ProbModel {
 protected:
 
     // the maximum length of phrase to be generated from the base measures
-    int maxLen_;
+    int maxLen_e_;
+    int maxLen_f_;
 
     // model probabilities
     PyDist< int,PyDenseIndex<int> > phrases_;
@@ -171,7 +172,7 @@ public:
         return ret;
     }
 
-	virtual void setMaxLen(int maxLen) { maxLen_ = maxLen; }
+	virtual void setMaxLen(int maxLenE, int maxLenF) { maxLen_e_ = maxLenE; maxLen_f_ = maxLenF;}
 
     bool getRememberNull() { return rememberNull_; }
     void setRememberNull(bool rememberNull) { rememberNull_ = rememberNull; }

--- a/src/include/pialign/model-length.h
+++ b/src/include/pialign/model-length.h
@@ -23,7 +23,7 @@ public:
 		
 	}
 	
-	void setMaxLen(int maxLen);
+	void setMaxLen(int maxLenE, int maxLenF);
     
     Prob calcSentProb(const Span & mySpan) const { return sentPen_; }
     bool isHierarchical() { return true; }

--- a/src/include/pialign/pialign.h
+++ b/src/include/pialign/pialign.h
@@ -9,6 +9,7 @@
 #include "pialign/look-base.h"
 #include "gng/string.h"
 #include "gng/symbol-set.h"
+#include <tr1/unordered_map>
 #include <algorithm>
 #include <fstream>
 #include <iostream>
@@ -100,7 +101,8 @@ protected:
     bool shuffle_;         // shuffle the order of sentences for sampling
     int wordIters_;        // the number number of iterations to do with the word-based model (0)
     Prob annealLevel_;     // the current level of annealing
-    int maxPhraseLen_;     // the maximum phrase size  
+    int maxPhraseLen_e_;   // the maximum phrase size (english side)
+    int maxPhraseLen_f_;   // the maximum phrase size (french side) 
     int printMax_;         // the maximum phrase size to print  
     int printMin_;         // the minimum phrase size to print  
     int maxSentLen_;       // the maximum size of a sentence  
@@ -117,8 +119,10 @@ protected:
     static const int MODEL_FLAT = 1;
     static const int MODEL_LENGTH = 2;
     bool forceWord_;        // force the aligner to generate at-most-one alignments (phrase alignments according to the model are bracketed with {}) 
-    Prob avgPhraseLen_;        // the average length of an E phrase (for flat models, default 1)
-    Prob nullProb_;            // the probability null values
+    Prob avgPhraseLen_e_;        // the average length of an E phrase (for flat models, default 1)
+    Prob avgPhraseLen_f_;        // the average length of an F phrase (for flat models, default 1)
+    Prob nullProb_e_;            // the probability null values for E side
+    Prob nullProb_f_;            // the probability null values for F side
     Prob termStrength_, termPrior_; // the strength of the type dist and prior of the terminal
     Prob defDisc_, defStren_; // the default discounts and strengths of the Pitman-Yor process
     
@@ -141,7 +145,8 @@ protected:
     // buffers and constants
     bool onSample_; // whether we are currently calculating a sample or not
     std::vector<Prob> patternBuffer_; // a buffer holding the log probabilities of each pattern type
-    std::vector<Prob> poisProbs_; // a buffer holding the log probabilities of the Poisson dist
+    std::vector<Prob> poisProbs_e_; // a buffer holding the log probabilities of the Poisson dist
+    std::vector<Prob> poisProbs_f_; // a buffer holding the log probabilities of the Poisson dist
     std::vector<BuildJob> buildJobs_; // sample building jobs
 
     // the base distribution
@@ -175,9 +180,10 @@ public:
     PIAlign() : samples_(1), sampRate_(1), burnIn_(9),
         babySteps_(1), babyStepLen_(0), annealSteps_(1), annealStepLen_(0), 
         batchLen_(1), numThreads_(1), shuffle_(true), wordIters_(0),
-        maxPhraseLen_(3), printMax_(7), printMin_(1), maxSentLen_(40), probWidth_(1e-4),
+        maxPhraseLen_e_(3), maxPhraseLen_f_(3), printMax_(7), printMin_(1), maxSentLen_(40), probWidth_(1e-4),
         useQueue_(false), viterbi_(false), lookType_(LOOK_IND),
-        modelType_(MODEL_HIER), forceWord_(true), avgPhraseLen_(0.01), nullProb_(0.01), 
+        modelType_(MODEL_HIER), forceWord_(true), avgPhraseLen_e_(0.01), nullProb_e_(0.01),
+        avgPhraseLen_f_(0.01), nullProb_f_(0.01), 
         termStrength_(1), termPrior_(1.0/3.0),
         defDisc_(-1), defStren_(-1),
         baseType_(BASE_MODEL1G), monotonic_(false), doReject_(false),

--- a/src/include/pialign/pialign.h
+++ b/src/include/pialign/pialign.h
@@ -9,7 +9,6 @@
 #include "pialign/look-base.h"
 #include "gng/string.h"
 #include "gng/symbol-set.h"
-#include <tr1/unordered_map>
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/src/lib/base-unigram.cc
+++ b/src/lib/base-unigram.cc
@@ -9,17 +9,17 @@ SpanProbMap * BaseUnigram::getBaseChart(const WordString & e, const WordString &
     Prob eProb, fProb, noSym; //, yesSym;
     for(int s = 0; s <= T; s++) {
         eProb = 0;
-        int actT = std::min(s+maxLen_,T);
+        int actT = std::min(s+maxLen_e_,T);
         for(int t = s; t <= actT; t++) {
             if(t != s) eProb += unigrams_[e[t-1]];
             for(int u = 0; u <= V; u++) {
                 fProb = 0;
-                int actV = std::min(u+maxLen_,V);
+                int actV = std::min(u+maxLen_f_,V);
                 for(int v = (s==t?u+1:u); v <= actV; v++) {
                     if(u != v) fProb += unigrams_[f[v-1]];
                     Span mySpan(s,t,u,v);
-                    noSym = fProb+eProb+poisProbs_[t-s]+poisProbs_[v-u];
-                    // std::cerr << "BaseUnigram::calcBaseProb"<<mySpan<<" == "<<fProb<<"+"<<eProb<<"+"<<poisProbs_[t-s]<<"+"<<poisProbs_[v-u]<<" == "<<noSym<<" --> "<<yesSym<<std::endl;
+                    noSym = fProb+eProb+poisProbs_e_[t-s]+poisProbs_f_[v-u];
+                    // std::cerr << "BaseUnigram::calcBaseProb"<<mySpan<<" == "<<fProb<<"+"<<eProb<<"+"<<poisProbs_e_[t-s]<<"+"<<poisProbs_f_[v-u]<<" == "<<noSym<<" --> "<<yesSym<<std::endl;
                     baseChart->insertProb(mySpan,noSym);       // add to the base chart
                 }
             }

--- a/src/lib/model-length.cc
+++ b/src/lib/model-length.cc
@@ -2,11 +2,13 @@
 #include "pialign/model-length.h"
 
 using namespace std;
+using namespace std::tr1;
 using namespace pialign;
 using namespace gng;
 
 
-void LengthModel::setMaxLen(int maxLen) {
+void LengthModel::setMaxLen(int maxLenE, int maxLenF) {
+    int maxLen = max(maxLenE,maxLenF);
     sepPhrases_ = std::vector< PyDist< WordId,PySparseIndex<WordId> > >(maxLen*2, PyDist< WordId,PySparseIndex<WordId> >(1.0,0.95));
     sepFor_ = std::vector< DirichletDist<int> >(maxLen*2,DirichletDist<int>(1.0,2)) ;
     sepTerm_ = std::vector< DirichletDist<int> >(maxLen*2,DirichletDist<int>(1.0,2)); 

--- a/src/lib/model-length.cc
+++ b/src/lib/model-length.cc
@@ -2,7 +2,6 @@
 #include "pialign/model-length.h"
 
 using namespace std;
-using namespace std::tr1;
 using namespace pialign;
 using namespace gng;
 

--- a/src/lib/pialign.cc
+++ b/src/lib/pialign.cc
@@ -28,7 +28,6 @@
 #endif
 
 using namespace std;
-using namespace std::tr1;
 using namespace pialign;
 using namespace gng;
 


### PR DESCRIPTION
Modified the code to accept different priors for the two sides (english-french) for the following parameters:
-avgphraselen
-nullprob
-maxphraselen

Got better results on aligning spanish phonemes to english words by about 5%-10% on the alignment F1-score.